### PR TITLE
Add a missing `order_by()` clause that led to the route's stations be…

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -9,7 +9,7 @@
 project = "eflips-model"
 copyright = "2024, Technische Universität Berlin"
 author = "Ludger Heide"
-release = "2.1.2"
+release = "2.1.3"
 
 
 # -- General configuration ---------------------------------------------------

--- a/eflips/model/network.py
+++ b/eflips/model/network.py
@@ -114,7 +114,9 @@ class Route(Base):
     """The trips."""
 
     assoc_route_stations: Mapped[List["AssocRouteStation"]] = relationship(
-        "AssocRouteStation", back_populates="route"
+        "AssocRouteStation",
+        back_populates="route",
+        order_by="AssocRouteStation.elapsed_distance",
     )
     """The associated route stations. This contains metadata about the stops on the route, such as the partial distance."""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "eflips-model"
-version = "2.1.2"
+version = "2.1.3"
 description = "A common data model for the eflips family of electric vehicle simulation & optimization tools."
 authors = [
 	"Ludger Heide <ludger.heide@tu-berlin.de>",


### PR DESCRIPTION
…ing returned in the wrong order through `Route.assoc_route_stations()`