### PR TITLE
Add loaded_mass defaults to export_scenario_to_json

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -9,7 +9,7 @@
 project = "eflips-model"
 copyright = "2024, Technische Universität Berlin"
 author = "Ludger Heide"
-release = "10.0.5"
+release = "10.0.6"
 
 
 # -- General configuration ---------------------------------------------------

--- a/eflips/model/util/export_json.py
+++ b/eflips/model/util/export_json.py
@@ -22,7 +22,7 @@ from sqlalchemy import inspect
 from sqlalchemy.orm import Mapper
 from sqlalchemy.orm import Query, Session, RelationshipDirection
 
-from eflips.model import Base, create_engine, Scenario
+from eflips.model import Base, create_engine, Scenario, Trip, TripType
 from eflips.model.depot import Area, AssocAreaProcess
 from eflips.model.general import AssocVehicleTypeVehicleClass, VehicleType
 from eflips.model.util.export import (
@@ -346,6 +346,17 @@ def export_scenario_to_json(
     scenario = session.query(Scenario).filter(Scenario.id == scenario_id).one_or_none()
     if not scenario:
         raise ValueError(f"No scenario with ID {scenario_id} found.")
+
+    # Set sensible loaded_mass defaults for trips before export
+    session.query(Trip).filter(
+        Trip.scenario_id == scenario_id,
+        Trip.trip_type == TripType.EMPTY,
+    ).update({"loaded_mass": 0})
+    session.query(Trip).filter(
+        Trip.scenario_id == scenario_id,
+        Trip.trip_type == TripType.PASSENGER,
+        Trip.loaded_mass == None,
+    ).update({"loaded_mass": 1360})
 
     # Add the scenario first
     result["Scenario"] = [serialize_object(scenario)]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "eflips-model"
-version = "10.0.5"
+version = "10.0.6"
 description = "A common data model for the eflips family of electric vehicle simulation & optimization tools."
 authors = [
 	"Ludger Heide <ludger.heide@tu-berlin.de>",


### PR DESCRIPTION
## Summary
- Set `loaded_mass=0` for EMPTY trips and `loaded_mass=1360` for PASSENGER trips with null loaded_mass before JSON export serialization
- This logic was previously in eflips-x's `ScenarioJsonExporter` and belongs in the export utility itself
- Patch version bump: 10.0.5 → 10.0.6

## Test plan
- [x] All 100 existing tests pass
- [ ] Verify JSON export produces correct loaded_mass values

🤖 Generated with [Claude Code](https://claude.com/claude-code)