### PR TITLE
Add slope-dependent term to consumption LUT

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -9,7 +9,7 @@
 project = "eflips-model"
 copyright = "2024, Technische Universität Berlin"
 author = "Ludger Heide"
-release = "11.0.0"
+release = "11.0.1"
 
 
 # -- General configuration ---------------------------------------------------

--- a/eflips/model/general.py
+++ b/eflips/model/general.py
@@ -56,6 +56,8 @@ if TYPE_CHECKING:
 
 
 class ScenarioType(PyEnum):
+    """Classifies a scenario by its provenance: original input, derived mutation, or simulation result."""
+
     SOURCE = auto()
     MUTATION = auto()
     SIMULATION = auto()
@@ -467,6 +469,8 @@ class Scenario(Base):
 
 
 class EnergySource(PyEnum):
+    """The kind of energy a vehicle uses for propulsion."""
+
     BATTERY_ELECTRIC = auto()
     DIESEL = auto()
     HYDROGEN = auto()
@@ -1175,15 +1179,21 @@ class ConsumptionLut(Base):
 
     @staticmethod
     def calc_consumption(
-        trip_distance: float, temperature: float, mass: float, duration: float
+        trip_distance: float,
+        temperature: float,
+        mass: float,
+        duration: float,
+        incline: float = 0.0,
     ) -> float:
         """
         This function calculates the consumption of the trip according to the model of
-        Ji, Bie, Zeng, Wang https://doi.org/10.1016/j.commtr.2022.100069
+        Ji, Bie, Zeng, Wang https://doi.org/10.1016/j.commtr.2022.100069, augmented
+        with a linear physics-based slope term (the original Ji model has none).
         :param trip_distance: Travelled distance in km
         :param temperature: Average temperature during trip in degrees Celsius
         :param mass: Curb weight + passengers in kg
         :param duration: Trip time in minutes
+        :param incline: Average road grade as a fraction (e.g. 0.05 = +5 % uphill, -0.03 = -3 % downhill). Defaults to 0 (level road).
         :return: Trip energy in kWh
         """
 
@@ -1210,10 +1220,16 @@ class ConsumptionLut(Base):
             k = ks[1]
         w2 = k * t_AC_percent * duration
 
+        # Slope contribution: m * g * sin(theta) per metre of travel.
+        # Small-angle: sin(theta) ≈ incline. Distance is in km, so multiply by
+        # 1000 m/km, then convert J → kWh by dividing by 3.6e6, giving / 3600.
+        gravity = 9.81  # m/s^2
+        w_slope: float = mass * gravity * incline * trip_distance / 3600.0  # kWh
+
         # Total trip energy
         # Possible Enhancement: Check why model energy is this low
         correction = 1.0  # Energy seems a bit low compared to other data
-        trip_energy = correction * (w1 + w2)
+        trip_energy = correction * (w1 + w2 + w_slope)
         trip_consumption = trip_energy / trip_distance
 
         return trip_consumption
@@ -1250,19 +1266,23 @@ class ConsumptionLut(Base):
         speed_steps = 11
         speeds = np.linspace(speed_range[0], speed_range[1], speed_steps, endpoint=True)
 
-        # Incline
-        incline = 0
+        # Inclines (fraction of rise / run, e.g. 0.05 = +5 %)
+        incline_range = [-0.10, 0.10]
+        incline_steps = 5
+        inclines = np.linspace(
+            incline_range[0], incline_range[1], incline_steps, endpoint=True
+        )
 
         # Calculate consumption
-        combinations = list(product(temperatures, speeds, level_of_loading))
+        combinations = list(product(temperatures, speeds, level_of_loading, inclines))
 
         consumption_list = []
         for combo in combinations:
-            temp, speed, lol = combo
+            temp, speed, lol, inc = combo
             duration = distance / speed * 60
             mass = (lol + 1) * delta_mass
             consumption = ConsumptionLut.calc_consumption(
-                distance, temp, mass, duration  # type: ignore
+                distance, temp, mass, duration, inc  # type: ignore
             )
             consumption_list.append(consumption)
 
@@ -1273,9 +1293,9 @@ class ConsumptionLut(Base):
                 ConsumptionLut.T_AMB,
                 ConsumptionLut.SPEED,
                 ConsumptionLut.LEVEL_OF_LOADING,
+                ConsumptionLut.INCLINE,
             ],
         )
-        consumption_table[ConsumptionLut.INCLINE] = incline
         consumption_table[ConsumptionLut.CONSUMPTION] = consumption_list
 
         return consumption_table

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "eflips-model"
-version = "11.0.0"
+version = "11.0.1"
 description = "A common data model for the eflips family of electric vehicle simulation & optimization tools."
 authors = [
 	"Ludger Heide <ludger.heide@tu-berlin.de>",

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -1533,8 +1533,16 @@ class TestConsumptionLut(TestGeneral):
         assert ConsumptionLut.SPEED in df.columns
         assert ConsumptionLut.CONSUMPTION in df.columns
 
-        # Check that the table has the expected number of rows (11x11x11 combinations)
-        assert len(df) == 11 * 11 * 11
+        # Check that the table has the expected number of rows (11x11x11x5 combinations:
+        # 11 temperatures, 11 speeds, 11 loadings, 5 inclines).
+        assert len(df) == 11 * 11 * 11 * 5
+
+        # The incline axis must include both downhill and uphill, with five
+        # distinct values evenly spanning -10 % to +10 %.
+        unique_inclines = sorted(df[ConsumptionLut.INCLINE].unique())
+        assert len(unique_inclines) == 5
+        assert unique_inclines[0] < 0
+        assert unique_inclines[-1] > 0
 
     def test_table_generator_invalid_vehicle_type(self, session, scenario):
         # Create a vehicle type without empty_mass and allowed_mass
@@ -1644,6 +1652,58 @@ class TestConsumptionLut(TestGeneral):
             match="vehicle_type_or_id must be either a VehicleType object or an int",
         ):
             ConsumptionLut.df_to_consumption_obj(df, 1, "invalid")
+
+    def test_calc_consumption_slope_zero_default(self):
+        # Omitting the incline argument must match passing incline=0.0 exactly.
+        args = (10.0, 20.0, 15000.0, 30.0)
+        assert ConsumptionLut.calc_consumption(
+            *args
+        ) == ConsumptionLut.calc_consumption(*args, 0.0)
+
+    def test_calc_consumption_slope_uphill_increases(self):
+        # Positive incline must raise consumption above the level-road baseline.
+        baseline = ConsumptionLut.calc_consumption(10.0, 20.0, 15000.0, 30.0, 0.0)
+        uphill = ConsumptionLut.calc_consumption(10.0, 20.0, 15000.0, 30.0, 0.05)
+        assert uphill > baseline
+
+    def test_calc_consumption_slope_downhill_decreases(self):
+        # Negative incline must lower consumption below the level-road baseline.
+        baseline = ConsumptionLut.calc_consumption(10.0, 20.0, 15000.0, 30.0, 0.0)
+        downhill = ConsumptionLut.calc_consumption(10.0, 20.0, 15000.0, 30.0, -0.05)
+        assert downhill < baseline
+
+    def test_calc_consumption_slope_linear_in_incline(self):
+        # The slope contribution is linear in incline.
+        baseline = ConsumptionLut.calc_consumption(10.0, 20.0, 15000.0, 30.0, 0.0)
+        c_x = ConsumptionLut.calc_consumption(10.0, 20.0, 15000.0, 30.0, 0.02)
+        c_2x = ConsumptionLut.calc_consumption(10.0, 20.0, 15000.0, 30.0, 0.04)
+        assert c_2x - baseline == pytest.approx(2.0 * (c_x - baseline), abs=1e-9)
+
+    def test_calc_consumption_slope_scales_with_mass(self):
+        # Doubling mass roughly doubles the slope coefficient. Mass also enters
+        # the Ji w1 term, so we isolate the slope contribution by subtracting the
+        # zero-incline baseline at each mass.
+        light_baseline = ConsumptionLut.calc_consumption(10.0, 20.0, 7500.0, 30.0, 0.0)
+        light_uphill = ConsumptionLut.calc_consumption(10.0, 20.0, 7500.0, 30.0, 0.05)
+        heavy_baseline = ConsumptionLut.calc_consumption(10.0, 20.0, 15000.0, 30.0, 0.0)
+        heavy_uphill = ConsumptionLut.calc_consumption(10.0, 20.0, 15000.0, 30.0, 0.05)
+
+        light_delta = light_uphill - light_baseline
+        heavy_delta = heavy_uphill - heavy_baseline
+        assert heavy_delta == pytest.approx(2.0 * light_delta, rel=1e-6)
+
+    def test_calc_consumption_slope_matches_physics(self):
+        # The slope contribution must equal mass * g * incline / 3600 in kWh/km.
+        trip_distance = 10.0
+        mass = 15000.0
+        incline = 0.05
+        baseline = ConsumptionLut.calc_consumption(trip_distance, 20.0, mass, 30.0, 0.0)
+        with_slope = ConsumptionLut.calc_consumption(
+            trip_distance, 20.0, mass, 30.0, incline
+        )
+        # Per km: (m * g * incline * trip_distance / 3600) / trip_distance
+        expected_delta = mass * 9.81 * incline / 3600.0
+        assert with_slope - baseline == pytest.approx(expected_delta, abs=1e-9)
 
 
 class TestTemperatures(TestGeneral):


### PR DESCRIPTION
## Summary
- The Ji et al. regression in `ConsumptionLut.calc_consumption()` ignores road grade, so generated LUTs were flat along the incline axis (always 0).
- Adds an optional `incline` argument (fraction, e.g. `0.05` = +5 %) and contributes `m · g · sin(θ) · distance / 3600` kWh — a linear physics-based slope term. Default `0.0` keeps every existing caller working.
- `table_generator()` now sweeps 5 inclines evenly from -10 % to +10 %, so the LUT grows from `11×11×11 = 1 331` to `11×11×11×5 = 6 655` rows. The `INCLINE` column was already part of `df_to_consumption_obj`'s schema, so no change is needed there.

The linear approximation matches measured-data LUTs (analyzed via `eflips-x/scripts/plot_slope_influence.py`) within ~10–15 %:

| bus | mass | measured kWh/km/% | physical |
|---|---|---|---|
| SPRINTER_6M | ~3000 kg | 0.085 | 0.082 |
| LLE_10M | ~12000 kg | 0.33 | 0.33 |
| NOR_BUS_12M | ~14000 kg | 0.43 | 0.38 |
| SOLARIS_18M | ~18000 kg | 0.56 | 0.49 |

## Test plan
- [x] Six new unit tests in `TestConsumptionLut` cover: zero-default back-compat, uphill increases, downhill decreases, linearity in incline, mass scaling, and exact match against `m · g · incline / 3600`.
- [x] `test_table_generator` updated for the new row count and asserts the incline axis spans both negative and positive values.
- [x] Full suite passes locally on Postgres (`114 passed`).
- [x] `black --check`, `mypy --strict eflips`, and `poetry check` all pass (also enforced via pre-commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)