### PR TITLE
Fix df_to_consumption_obj overwriting FK columns with NULL

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -9,7 +9,7 @@
 project = "eflips-model"
 copyright = "2024, Technische Universität Berlin"
 author = "Ludger Heide"
-release = "11.0.1"
+release = "11.0.2"
 
 
 # -- General configuration ---------------------------------------------------

--- a/eflips/model/general.py
+++ b/eflips/model/general.py
@@ -1338,16 +1338,22 @@ class ConsumptionLut(Base):
         ]
         data_points = np.array(df.loc[:, columns].values).tolist()
         values = np.array(df.loc[:, ConsumptionLut.CONSUMPTION].values).tolist()
-        return ConsumptionLut(
+        # Only pass the relationship when it is not None — otherwise SQLAlchemy
+        # writes the None through to the FK column on flush and overwrites the
+        # scenario_id / vehicle_class_id we just set.
+        kwargs = dict(
             name=f"Empirical consumption for {vehicle_class.name if vehicle_class else vehicle_class_id}",
             scenario_id=scenario_id,
-            scenario=scenario,
             vehicle_class_id=vehicle_class_id,
-            vehicle_class=vehicle_class,
             columns=columns,
             data_points=data_points,
             values=values,
         )
+        if scenario is not None:
+            kwargs["scenario"] = scenario
+        if vehicle_class is not None:
+            kwargs["vehicle_class"] = vehicle_class
+        return ConsumptionLut(**kwargs)
 
     @classmethod
     def from_vehicle_type(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "eflips-model"
-version = "11.0.1"
+version = "11.0.2"
 description = "A common data model for the eflips family of electric vehicle simulation & optimization tools."
 authors = [
 	"Ludger Heide <ludger.heide@tu-berlin.de>",

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -1621,9 +1621,15 @@ class TestConsumptionLut(TestGeneral):
 
         # Verify the consumption object was created with expected values
         assert consumption.scenario_id == scenario.id
-        assert consumption.scenario is None  # Should be None when using IDs
         assert consumption.vehicle_class_id == vehicle_class.id
-        assert consumption.vehicle_class is None  # Should be None when using IDs
+
+        # Flushing must preserve the FK columns. Previously the constructor was
+        # called with `scenario=None`/`vehicle_class=None` alongside the IDs,
+        # which made SQLAlchemy overwrite the FK with NULL on flush.
+        session.add(consumption)
+        session.flush()
+        assert consumption.scenario_id == scenario.id
+        assert consumption.vehicle_class_id == vehicle_class.id
 
     def test_df_to_consumption_obj_invalid_inputs(self):
         # Create a simple dataframe


### PR DESCRIPTION
## Summary
- `ConsumptionLut.df_to_consumption_obj` called the constructor with both `scenario_id=<int>` and `scenario=None` (same for `vehicle_class`) when the caller passed bare IDs. SQLAlchemy writes the relationship through to its FK column on flush, so the int got overwritten with `NULL` and the row was rejected by the `NOT NULL` constraint on `ConsumptionLut.scenario_id`.
- Minimal fix: only pass the relationship kwarg when it is not `None`. The `Scenario`/`VehicleClass` branches already work because their relationship carries a valid FK.
- Extended the existing `test_df_to_consumption_obj_with_ids` to `session.flush()` — without the fix it reproduces the original `IntegrityError`; with the fix it passes.

## Test plan
- [x] `pytest tests/test_general.py` — 49 passed
- [x] `black --check` clean
- [x] `mypy eflips --explicit-package-bases --strict` clean
- [x] Verified the new flush assertion fails on `main` (reproduces the reported `IntegrityError: NOT NULL constraint failed: ConsumptionLut.scenario_id`) and passes with the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)